### PR TITLE
remove schema and table name from RLS policy definitions

### DIFF
--- a/src/pg-backend.ts
+++ b/src/pg-backend.ts
@@ -534,8 +534,6 @@ export class PostgresBackend implements SQLBackend {
             if (!isTrueClause(permission.rowClause)) {
               const policyName = [
                 permission.privilege,
-                permission.table.schema,
-                permission.table.name,
                 permission.user.name,
               ]
                 .join("_")
@@ -562,8 +560,6 @@ export class PostgresBackend implements SQLBackend {
             if (!isTrueClause(permission.rowClause)) {
               const policyName = [
                 permission.privilege,
-                permission.table.schema,
-                permission.table.name,
                 permission.user.name,
               ]
                 .join("_")
@@ -590,8 +586,6 @@ export class PostgresBackend implements SQLBackend {
             if (!isTrueClause(permission.rowClause)) {
               const policyName = [
                 permission.privilege,
-                permission.table.schema,
-                permission.table.name,
                 permission.user.name,
               ]
                 .join("_")
@@ -617,8 +611,6 @@ export class PostgresBackend implements SQLBackend {
             if (!isTrueClause(permission.rowClause)) {
               const policyName = [
                 permission.privilege,
-                permission.table.schema,
-                permission.table.name,
                 permission.user.name,
               ]
                 .join("_")

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -943,7 +943,7 @@ describe("test-complete-1", async () => {
           "INSERT INTO app.users (name, org_id) VALUES ('cam', '42');",
         ),
         {
-          message: `new row violates row-level security policy "insert_app_users_${user3}" for table "users"`,
+          message: `new row violates row-level security policy "insert_${user3}" for table "users"`,
         },
       );
     });
@@ -1202,3 +1202,41 @@ describe("object type strictness", async () => {
     );
   });
 });
+
+describe("long table names", async () => {
+  await it("should work with long table names and multiple users", async () => {
+    const db = dbNameGenerator();
+    const user1 = userNameGenerator();
+    const user2 = userNameGenerator();
+    const useClient1 = dbClientGenerator(dbUrl(user1, "blah", db));
+    const useClient2 = dbClientGenerator(dbUrl(user2, "blah", db));
+    
+    let teardown: () => Promise<void> = async () => {};
+
+    before(async () => {
+      teardown = await setupEnv("long-table-name", "long-table-name", db, {
+        user1,
+        user2
+      });
+    });
+
+    after(async () => {
+      await teardown();
+    });
+
+    for (const [user, useClient] of [
+      ["user1", useClient1],
+      ["user2", useClient2],
+    ] as const) {
+      await it(`${user}: can access test.articles_but_with_an_extremely_long_table_name`, async () => {
+        await useClient(async (client) => {
+          const result = await client.query("SELECT * FROM test.articles_but_with_an_extremely_long_table_name");
+          assert.equal(result.rowCount, 4);
+        });
+      });
+    }
+  })
+})
+  
+
+  

--- a/test/envs/long-table-name/setup.sql
+++ b/test/envs/long-table-name/setup.sql
@@ -1,0 +1,32 @@
+BEGIN;
+
+CREATE SCHEMA test;
+
+CREATE TABLE test.articles_but_with_an_extremely_long_table_name (
+    id SERIAL PRIMARY KEY,
+    title VARCHAR(255) NOT NULL,
+    content TEXT NOT NULL,
+    author VARCHAR(100),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+INSERT INTO test.articles_but_with_an_extremely_long_table_name (title, content, author, created_at, updated_at) VALUES
+('Article 1', 'Content for article 1', 'Author A', '2023-01-01 10:00:00', '2023-01-01 10:00:00'),
+('Article 2', 'Content for article 2', 'Author B', '2023-01-02 10:00:00', '2023-01-02 11:00:00'),
+('Article 3', 'Content for article 3', 'Author C', '2023-01-03 10:00:00', '2023-01-03 12:00:00'),
+('Article 4', 'Content for article 4', 'Author A', '2023-01-04 10:00:00', '2023-01-04 13:00:00'),
+('Article 5', 'Content for article 5', 'Author B', '2023-01-05 10:00:00', '2023-01-05 14:00:00'),
+('Article 6', 'Content for article 6', 'Author C', '2023-01-06 10:00:00', '2023-01-06 15:00:00'),
+('Article 7', 'Content for article 7', 'Author A', '2023-01-07 10:00:00', '2023-01-07 16:00:00'),
+('Article 8', 'Content for article 8', 'Author B', '2023-01-08 10:00:00', '2023-01-08 17:00:00'),
+('Article 9', 'Content for article 9', 'Author C', '2023-01-09 10:00:00', '2023-01-09 18:00:00'),
+('Article 10', 'Content for article 10', 'Author A', '2023-01-10 10:00:00', '2023-01-10 19:00:00'),
+('Article 11', 'Content for article 11', 'Author B', '2023-01-11 10:00:00', '2023-01-11 20:00:00'),
+('Article 12', 'Content for article 12', 'Author C', '2023-01-12 10:00:00', '2023-01-12 21:00:00');
+
+CREATE USER {{user1}} WITH PASSWORD 'blah';
+
+CREATE USER {{user2}} WITH PASSWORD 'blah';
+
+COMMIT;

--- a/test/envs/long-table-name/teardown.sql
+++ b/test/envs/long-table-name/teardown.sql
@@ -1,0 +1,2 @@
+DROP ROLE {{user1}};
+DROP ROLE {{user2}};

--- a/test/rules/long-table-name.polar
+++ b/test/rules/long-table-name.polar
@@ -1,0 +1,10 @@
+
+allow(actor, "usage", "test") if isAppUser(actor);
+
+allow(user, action, table)
+    if isAppUser(user)
+    and action in ["select", "insert", "update", "delete"]
+    and table == "test.articles_but_with_an_extremely_long_table_name"
+    and table.row.author = "Author A";
+
+isAppUser(actor) if actor in [user1, user2];


### PR DESCRIPTION
Postgres will truncate policy names to 63 characters. Because of this, long table names can cause conflicts in RLS policies.

Since RLS policy names only need to be unique to the table, this uses just the permission and role name.

Closes #1 